### PR TITLE
Escape quotes

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -55,11 +55,11 @@ class Widget extends InputWidget
         foreach ($data as $key => $value) {
 
             if ( !isset($flipped_selected[$value->{$this->data_id}]) ) {
-                $ret .= '<option value="' . $value->{$this->data_id} . '">' . $value->{$this->data_value} . '</option>' . "\n";
+                $ret .= '<option value="' . addslashes($value->{$this->data_id}) . '">' . $value->{$this->data_value} . '</option>' . "\n";
         } else {
                 $cnt++;
                 $ret_sel .= '$("#dlb-'.$this->attribute.' .selected").
-                append("<option value=' . $value->{$this->data_id} . '>' . $value->{$this->data_value} . '</option>");';
+                append("<option value=' . addslashes($value->{$this->data_id}) . '>' . $value->{$this->data_value} . '</option>");';
             }
         }
         $ret .= '</select>';


### PR DESCRIPTION
To prevent Javascript and HTML issues when values contain quites, quotes are now escaped with addslashes.
